### PR TITLE
Assets (style, locale) added to citeproc from citeproc-js

### DIFF
--- a/lib/citeproc.rb
+++ b/lib/citeproc.rb
@@ -17,6 +17,7 @@ require 'citeproc/date'
 require 'citeproc/names'
 require 'citeproc/selector'
 require 'citeproc/bibliography'
+require 'citeproc/assets'
 
 require 'citeproc/engine'
 require 'citeproc/processor'

--- a/lib/citeproc/assets.rb
+++ b/lib/citeproc/assets.rb
@@ -1,0 +1,66 @@
+require 'uri'
+
+module CiteProc
+  module Asset
+    
+    def self.included(base)
+      base.extend(ClassMethods)
+    end
+    
+    attr_accessor :asset
+    
+    alias to_s asset
+
+    def inspect
+      to_s.inspect
+    end
+    
+    module ClassMethods
+      
+      attr_accessor :root, :extension, :prefix
+      
+      def load(asset)
+        instance = new
+        case
+        when File.exists?(asset)
+          instance.asset = read(asset)
+        when File.exists?(File.join(root.to_s, extend_name(asset)))
+          instance.asset = read(File.join(root.to_s, extend_name(asset)))
+        else
+          instance.asset = asset
+        end
+        instance
+      end
+      
+      private
+
+      def read(name)
+        io = open(name, 'r:UTF-8')
+        io.read
+      ensure
+        io.close
+      end
+
+      def extend_name(file)
+        file = File.extname(file).empty? ? [file, extension].compact.join : file
+        file = file.start_with?(prefix.to_s) ? file : [prefix,file].join
+        file
+      end
+    end
+    
+  end
+  
+  class Style
+    include Asset
+    @root = '/usr/local/share/citation-style-language/styles'.freeze
+    @extension = '.csl'.freeze
+  end
+  
+  class Locale
+    include Asset
+    @root = '/usr/local/share/citation-style-language/locales'.freeze
+    @extension = '.xml'.freeze
+    @prefix = 'locales-'
+  end
+    
+end

--- a/lib/citeproc/processor.rb
+++ b/lib/citeproc/processor.rb
@@ -17,15 +17,28 @@ module CiteProc
 
     attr_reader :options, :engine, :items
     
-    def_delegators :@engine, :process, :append, :preview, :bibliography, :style, :style=, :abbreviate, :abbreviations, :abbreviations=
+    def_delegators :@engine, :process, :append, :preview, :bibliography, :style, :abbreviate, :abbreviations, :abbreviations=
      
     def initialize(options = {})
       @options = Processor.defaults.merge(options)
       @engine = Engine.autodetect(@options).new(:processor => self)
+      style = @options[:style]
+      locales = @options[:locale]
       @items = {}
     end
     
-		
+		def style=(style)
+		  @style = Style.load(style.to_s)
+		  @engine.style = @style
+		  @style
+	  end
+	  
+	  def locales=(locale)
+      @locales = { locale.to_sym => Locale.load(locale.to_s) }
+      @engine.locales = @locales
+      @locales
+    end
+    
 		private
 		
 		def extract_citation_data(items, options = {})

--- a/spec/citeproc/assets_spec.rb
+++ b/spec/citeproc/assets_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+require 'tempfile'
+
+module CiteProc
+  
+  describe 'Assets' do
+    let(:file) { Tempfile.new('asset') }
+    let(:root) { File.dirname(file.path) }
+    let(:name) { File.basename(file.path) }
+    let(:extension) { File.extname(name) }
+  
+    before(:all) do
+      file.write("asset content\n")
+      file.close
+    end
+  
+    after(:all) { file.unlink }
+
+    describe 'Style' do
+
+      before(:all) do
+        @default_root = Style.root
+        @default_extension = Style.extension
+        Style.root = root
+        Style.extension = extension
+      end
+      
+      after(:all) do
+        Style.root = @default_root
+        Style.extension = @default_extension
+      end
+    
+      describe '.load' do  
+      
+        it 'accepts an absolute file name' do
+          Style.load(file.path).to_s.should == "asset content\n"
+        end
+
+        it 'accepts a file name' do
+          Style.load(name).to_s.should == "asset content\n"
+        end
+
+        it 'accepts a file name without extension' do
+          Style.load(name.sub(/#{extension}$/,'')).to_s.should == "asset content\n"
+        end
+                
+                
+        it 'accepts a uri' do
+          pending
+        end
+      
+        it 'returns the given string if it is neither file nor uri' do
+          Style.load('foo bar!').to_s.should == 'foo bar!'
+        end
+      
+      end
+    
+    end
+  end
+end


### PR DESCRIPTION
moving assets (style, locale) from citeproc-js into citeproc, the engine should receive a string

I moved the style and locale loading from citeproc-js to citeproc.  I know we discussed potentially not doing this, but I was starting to duplicate effort there.  Let me know what you think.  I'll continue to work on the Processor API.  We will need to remove this from citeproc-js at some point.
