### PR TITLE
Proposed fix for issue 41

### DIFF
--- a/lib/citeproc/attributes.rb
+++ b/lib/citeproc/attributes.rb
@@ -26,7 +26,13 @@ module CiteProc
     alias []= write_attribute
 
     def attribute?(key)
-      value = read_attribute key
+      # this method is used only for conditional type access.
+      # When included on an object with read observations, don't count this as an observable read
+      if respond_to? :unobservable_read_attribute
+        value = unobservable_read_attribute key
+      else
+        value = read_attribute key
+      end
 
       return false if value.nil?
       return false if value.respond_to?(:empty?) && value.empty?

--- a/spec/citeproc/attributes_spec.rb
+++ b/spec/citeproc/attributes_spec.rb
@@ -49,5 +49,49 @@ module CiteProc
 
     end
 
+    describe '#attribute?' do
+      it 'return false for unset attribute' do
+        expect(A.new.attribute?(:foo)).to eq(false)
+      end
+
+      it 'return false for empty attribute value' do
+        a = A.new
+        a[:foo]=''
+        expect(a.attribute?(:foo)).to eq(false)
+      end
+
+      it 'return false for attribute value set to string "false"' do
+        a = A.new
+        a[:foo]='false'
+        expect(a.attribute?(:foo)).to eq(false)
+      end
+      it 'return false for attribute value set to string "no"' do
+        a = A.new
+        a[:foo]='no'
+        expect(a.attribute?(:foo)).to eq(false)
+      end
+      it 'return false for attribute value set to string "never"' do
+        a = A.new
+        a[:foo]='never'
+        expect(a.attribute?(:foo)).to eq(false)
+      end
+      it 'return true for attribute with value' do
+        a = A.new
+        a[:foo]='bar'
+        expect(a.attribute?(:foo)).to eq(true)
+      end
+
+      describe 'properly handle usage on Observable objects' do
+        it 'should use unobservable_read_attribute method when available' do
+          a = A.new
+          def a.unobservable_read_attribute(attr)
+            return 'tuna'
+          end
+          expect(a).to receive(:unobservable_read_attribute)
+          a.attribute?(:foo)
+        end
+      end
+    end
+
   end
 end

--- a/spec/citeproc/item_spec.rb
+++ b/spec/citeproc/item_spec.rb
@@ -75,5 +75,17 @@ module CiteProc
         expect(Item.new(:issued => 1976).dup[:issued].year).to eq(1976)
       end
     end
+
+    describe '#attribute?' do
+      it 'should not trigger an observable read' do
+        obs = Object.new
+        def obs.update
+        end
+        expect(obs).not_to receive(:update)
+        item = Item.new(:issued => 1976)
+        item.add_observer(obs)
+        item.attribute?(:issued)
+      end
+    end
   end
 end


### PR DESCRIPTION
For https://github.com/inukshuk/citeproc-ruby/issues/41 - making the attribute? method use  unobservable_read_attribute when available