### PR TITLE
Adding director for motion_picture.

### DIFF
--- a/lib/citeproc/variable.rb
+++ b/lib/citeproc/variable.rb
@@ -19,7 +19,7 @@ module CiteProc
 
       :names => %w{
         author collection-editor composer container-author recipient editor
-        editorial-director illustrator interviewer original-author translator
+        editorial-director illustrator interviewer original-author translator director
       },
 
       :number => %w{


### PR DESCRIPTION
I created a CSL that was loaded with the supporting behavior but kept running into errors. 

I drilled it down to CiteProc::Variable not recognizing the field, so this PR is to add it. 

I didn't see a mechanism in place that allowed for such behavior since fields is frozen. 

Please review and/or provide assistance into the intended action if this isn't necessary.