### PR TITLE
Fix deprecation warning on Ruby 2.7 + update CI config 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
 language: ruby
-sudo: false
-matrix:
+os: linux
+jobs:
   include:
-  - rvm: 2.5
+  - rvm: 2.7
     env: WITH_COVERALLS=true
+  - rvm: 2.6
+    env: WITH_COVERALLS=false
+  - rvm: 2.5
+    env: WITH_COVERALLS=false
   - rvm: 2.4
     env: WITH_COVERALLS=false
   - rvm: 2.3

--- a/lib/citeproc/bibliography.rb
+++ b/lib/citeproc/bibliography.rb
@@ -212,9 +212,9 @@ module CiteProc
       join
     end
 
-    def each
+    def each(&block)
       if block_given?
-        references.each(&Proc.new)
+        references.each(&block)
         self
       else
         to_enum

--- a/lib/citeproc/citation_data.rb
+++ b/lib/citeproc/citation_data.rb
@@ -169,12 +169,12 @@ module CiteProc
 
     alias update merge
 
-    def each
+    def each(&block)
       if block_given?
         if sorted?
-          sorted_items.each(&Proc.new)
+          sorted_items.each(&block)
         else
-          items.each(&Proc.new)
+          items.each(&block)
         end
 
         self

--- a/lib/citeproc/engine.rb
+++ b/lib/citeproc/engine.rb
@@ -35,9 +35,9 @@ module CiteProc
       end
 
       # Loads the engine with the given name and returns the engine class.
-      def detect!(name)
+      def detect!(name, &block)
         load(name)
-        block_given? ? detect(name, &Proc.new) : detect(name)
+        block_given? ? detect(name, &block) : detect(name)
       end
 
       # Returns the best available engine class or nil.

--- a/lib/citeproc/item.rb
+++ b/lib/citeproc/item.rb
@@ -165,9 +165,9 @@ module CiteProc
     # @yieldparam field [Symbol] the field name
     # @yieldparam value [Variable] the value
     # @return [self,Enumerator] the item or an enumerator if no block is given
-    def each
+    def each(&block)
       if block_given?
-        attributes.each_pair(&Proc.new)
+        attributes.each_pair(&block)
         self
       else
         to_enum
@@ -188,9 +188,9 @@ module CiteProc
     #
     # @yieldparam value [Variable] the value
     # @return [self,Enumerator] the item or an enumerator if no block is given
-    def each_value
+    def each_value(&block)
       if block_given?
-        attributes.each_value(&Proc.new)
+        attributes.each_value(&block)
         self
       else
         enum_for :each_value

--- a/lib/citeproc/names.rb
+++ b/lib/citeproc/names.rb
@@ -689,9 +689,9 @@ module CiteProc
     #
     # @yieldparam name [Name] a name in the list
     # @return [self,Enumerator] self or an enumerator if no block is given
-    def each
+    def each(&block)
       if block_given?
-        names.each(&Proc.new)
+        names.each(&block)
         self
       else
         to_enum


### PR DESCRIPTION
Pretty much like https://github.com/inukshuk/csl-ruby/pull/8 (which is required to get rid of the remaining deprecation warnings still appearing here).

Like the other pull request, remember to bump gem version when releasing as I haven't done it.