### PR TITLE
Normalize names with decomposed diacritics 

### DIFF
--- a/lib/citeproc/names.rb
+++ b/lib/citeproc/names.rb
@@ -152,7 +152,7 @@ module CiteProc
     #
     # @return [Boolean] whether or not the name is romanesque
     def romanesque?
-      !!([given, family].join.gsub(Variable.markup, '') =~ Name.romanesque)
+      !!([given&.unicode_normalize(:nfc), family&.unicode_normalize(:nfc)].join.gsub(Variable.markup, '') =~ Name.romanesque)
     end
 
     alias byzantine? romanesque?

--- a/spec/citeproc/names_spec.rb
+++ b/spec/citeproc/names_spec.rb
@@ -11,6 +11,8 @@ module CiteProc
     let(:plato) { Name.new(:given => 'Plato') }
     let(:aristotle) { Name.new(:given => 'Ἀριστοτέλης') }
     let(:dostoyevksy) { Name.new(:given => 'Фёдор Михайлович', :family => 'Достоевский') }
+    let(:saer_decomposed) { Name.new(:family => 'Saer', :given => 'Juan José') }
+    let(:saer_precomposed) { Name.new(:family => 'Saer', :given => 'Juan José') }
 
     let(:utf) { Name.new(
       :given => 'Gérard',
@@ -360,6 +362,18 @@ module CiteProc
 
           it 'for normal names it prints them as "family, given"' do
             expect(poe.sort_order!.format).to eq('Poe, Edgar Allen')
+          end
+
+          context 'with decomposed accents at the end' do
+            it 'prints them as "family, given"' do
+              expect(saer_decomposed.sort_order!.format).to eq('Saer, Juan José')
+            end
+          end
+
+          context 'with precomposed accents at the end' do
+            it 'prints them as "family, given"' do
+              expect(saer_precomposed.sort_order!.format).to eq('Saer, Juan José')
+            end
           end
 
           it 'particles come after given name by default' do

--- a/spec/citeproc/names_spec.rb
+++ b/spec/citeproc/names_spec.rb
@@ -364,15 +364,21 @@ module CiteProc
             expect(poe.sort_order!.format).to eq('Poe, Edgar Allen')
           end
 
-          context 'with decomposed accents at the end' do
-            it 'prints them as "family, given"' do
-              expect(saer_decomposed.sort_order!.format).to eq('Saer, Juan José')
-            end
-          end
-
-          context 'with precomposed accents at the end' do
-            it 'prints them as "family, given"' do
+          context 'with accents at the end of the name' do
+            it 'prints with precomposed accent as "family, given"' do
+              expect(!saer_precomposed.short_form?).to be true
+              expect(!saer_precomposed.demote_particle?).to be true
+              expect(!saer_precomposed.romanesque?).to be false
+              expect(saer_precomposed.static_order?).to be false
               expect(saer_precomposed.sort_order!.format).to eq('Saer, Juan José')
+            end
+
+            it 'prints with decomposed accent as "family, given"' do
+              expect(!saer_decomposed.short_form?).to be true
+              expect(!saer_decomposed.demote_particle?).to be true
+              expect(!saer_decomposed.romanesque?).to be false
+              expect(saer_decomposed.static_order?).to be false
+              expect(saer_decomposed.sort_order!.format).to eq('Saer, Juan José')
             end
           end
 


### PR DESCRIPTION
When a name ends with a decomposed diacritic, the romanesque? method does not recognize that it is a romanesque name. Normalize the name to ensure it is recognized as a Latin name.